### PR TITLE
Add dotenv-safe functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ ARGUMENTS
            Command to run
 
 OPTIONS
-       -e ENV, --env-file=ENV
+       -e FILE, --env-file=FILE
            The .env files to read variables from.
 
        --help[=FMT] (default=auto)
            Show this help in format FMT. The value FMT must be one of `auto',
            `pager', `groff' or `plain'. With `auto', the format is `pager` or
            `plain' whenever the TERM env var is `dumb' or undefined.
+
+       -s FILE, --safe=FILE
+           The .env file with keys that need to be provided.
 
        --version
            Show version information.
@@ -46,9 +49,6 @@ EXIT STATUS
        124 on command line parsing errors.
 
        125 on unexpected internal errors (bugs).
-
-BUGS
-       File an issue athttps://github.com/ulrikstrid/reenv/issues
 ```
 
 ### example

--- a/executable/ReenvApp.re
+++ b/executable/ReenvApp.re
@@ -1,15 +1,20 @@
 open Cmdliner;
 
-let start = (envFiles, command, args) => {
-  Reenv.main(~envFiles, ~command, args);
-};
-
 let envFiles = {
   let doc = "The .env files to read variables from.";
   Arg.(
     value
     & opt_all(non_dir_file, [])
-    & info(["e", "env-file"], ~docv="ENV", ~doc)
+    & info(["e", "env-file"], ~docv="FILE", ~doc)
+  );
+};
+
+let safeFile = {
+  let doc = "The .env file with keys that need to be provided.";
+  Arg.(
+    value
+    & opt(some(non_dir_file), None)
+    & info(["s", "safe"], ~docv="FILE", ~doc)
   );
 };
 
@@ -31,19 +36,23 @@ let args = {
   );
 };
 
+let start = (envFiles, safeFile, command, args) => {
+  Reenv.main(~envFiles, ~safeFile, ~command, args);
+};
+
 let () = {
   let doc = "Read dotenv file(s) and supply them to the program.";
   let man = [
     `S(Manpage.s_bugs),
     `P("File an issue athttps://github.com/ulrikstrid/reenv/issues"),
   ];
-  let term = Term.(const(start) $ envFiles $ command $ args);
+  let term = Term.(const(start) $ envFiles $ safeFile $ command $ args);
   let info =
     Term.info(
       "reenv",
       ~doc,
       ~man,
-      ~version="0.2.1",
+      ~version="0.3.0",
       ~exits=Term.default_exits,
     );
 

--- a/library/Reenv.rei
+++ b/library/Reenv.rei
@@ -1,5 +1,7 @@
 module Util = Util;
 
+exception Missing_keys(string);
+
 type t;
 
 let make: unit => t;
@@ -7,8 +9,17 @@ let make: unit => t;
 let get_opt: (string, t) => option(string);
 let get_exn: (string, t) => string;
 
-let array_of_t: t => array(string);
+let array_of_t: t => array((string, string));
 
-let main: (~envFiles: list(string), ~command: string, list(string)) => 'a;
+let checkSafe: (~safeFile: string, t) => unit;
+
+let main:
+  (
+    ~envFiles: list(string),
+    ~safeFile: option(string),
+    ~command: string,
+    list(string)
+  ) =>
+  'a;
 
 let t_of_in_channel: (t, in_channel) => t;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reenv",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "dotenv-cli written in reason",
   "esy": {
     "build": "dune build -p #{self.name}",

--- a/test/DotenvCompliance.re
+++ b/test/DotenvCompliance.re
@@ -64,9 +64,10 @@ describe("dotenv compliance", utils => {
         |> Reenv.t_of_in_channel(Reenv.make())
         |> Reenv.array_of_t;
 
-      let first = env[0];
+      let (key, value) = env[0];
 
-      expect.string(first).toEqual("JSON={\"foo\": \"bar\"}");
+      expect.string(key).toEqual("JSON");
+      expect.string(value).toEqual("{\"foo\": \"bar\"}");
     },
   );
 
@@ -76,9 +77,10 @@ describe("dotenv compliance", utils => {
       |> Reenv.t_of_in_channel(Reenv.make())
       |> Reenv.array_of_t;
 
-    let first = env[0];
+    let (key, value) = env[0];
 
-    expect.string(first).toEqual({|NEW_LINE=new
+    expect.string(key).toEqual("NEW_LINE");
+    expect.string(value).toEqual({|new
 line|});
   });
 });

--- a/test/SafeTest.re
+++ b/test/SafeTest.re
@@ -1,7 +1,25 @@
 open TestFramework;
 
-describe("Safe functionality", utils =>
-  utils.test("1 + 1 should equal 2", ({expect}) =>
-    expect.int(1 + 2).toBe(3)
-  )
-);
+describe("Safe functionality", utils => {
+  let checkIfSafe = Reenv.checkSafe(~safeFile="./fixtures/.env");
+
+  utils.test("Should raise if not all keys are there", ({expect}) => {
+    expect.fn(() => checkIfSafe(Reenv.make())).toThrow();
+
+    try (checkIfSafe(Reenv.make())) {
+    | Reenv.Missing_keys(missingKeys) =>
+      expect.string(missingKeys).toMatch("TEST");
+      expect.string(missingKeys).toMatch("TEST2");
+    // TODO: re-add this test when this is fixed
+    // https://github.com/facebookexperimental/reason-native/issues/121
+    // expect.string(missingKeys).toMatch("TEST3");
+    };
+  });
+
+  utils.test("is fine when all the keys are provided", ({expect}) => {
+    let env =
+      open_in_bin("./fixtures/.env") |> Reenv.t_of_in_channel(Reenv.make());
+
+    expect.same(checkIfSafe(env), ());
+  });
+});

--- a/test/SafeTest.re
+++ b/test/SafeTest.re
@@ -3,18 +3,11 @@ open TestFramework;
 describe("Safe functionality", utils => {
   let checkIfSafe = Reenv.checkSafe(~safeFile="./fixtures/.env");
 
-  utils.test("Should raise if not all keys are there", ({expect}) => {
-    expect.fn(() => checkIfSafe(Reenv.make())).toThrow();
-
-    try (checkIfSafe(Reenv.make())) {
-    | Reenv.Missing_keys(missingKeys) =>
-      expect.string(missingKeys).toMatch("TEST");
-      expect.string(missingKeys).toMatch("TEST2");
-    // TODO: re-add this test when this is fixed
-    // https://github.com/facebookexperimental/reason-native/issues/121
-    // expect.string(missingKeys).toMatch("TEST3");
-    };
-  });
+  utils.test("Should raise if not all keys are there", ({expect}) =>
+    expect.fn(() => checkIfSafe(Reenv.make())).toThrowException(
+      Reenv.Missing_keys("TEST2, TEST, TEST3"),
+    )
+  );
 
   utils.test("is fine when all the keys are provided", ({expect}) => {
     let env =


### PR DESCRIPTION
This adde the possibility to use `--safe <file>` to make sure all the keys in that file are provided by the other .env files.

If they are not there it will fail spectacularly.

Fixes #3